### PR TITLE
Add context menu on tracks and albums to improve navigation

### DIFF
--- a/app/frontend/components/AlbumItem.vue
+++ b/app/frontend/components/AlbumItem.vue
@@ -2,7 +2,7 @@
   <ion-item
     button
     :router-link="{ name: 'album', params: { id: album.id } }"
-    class="rounded"
+    class="rounded group"
     :detail="false"
     lines="none"
   >
@@ -14,34 +14,58 @@
         />
         <ion-icon
           v-else
-          :icon="albums"
+          :icon="icons.album"
           class="text-slate-300 text-5xl"
+        />
+        <ion-icon
+          :id="`album-${album.id}-popover`"
+          :ios="icons.iosEllipsis"
+          :md="icons.mdEllipsis"
+          class="absolute bottom-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity block ratio-square rounded-full bg-black/50 text-white p-1.5 text-xs"
+          @click.prevent=""
         />
       </div>
       <h2 class="text-sm">
         {{ album.title }}
       </h2>
-      <p>{{ album.artist.name }} • {{ album.released }}</p>
+      <p>
+        <span v-if="showArtist">{{ album.artist.name }} •</span>
+        {{ album.released }}
+      </p>
     </ion-label>
+    <ion-popover
+      :trigger="`album-${album.id}-popover`"
+      alignment="center"
+      translucent
+      dismiss-on-select
+      animated
+    >
+      <ion-list lines="full">
+        <ion-item
+          button
+          :detail-icon="icons.artist"
+          :router-link="{ name: 'artist', params: { id: album.artist?.id } }"
+        >
+          View Artist
+        </ion-item>
+      </ion-list>
+    </ion-popover>
   </ion-item>
 </template>
 
-<script>
-import { IonItem, IonLabel, IonImg, IonIcon } from '@ionic/vue'
-import { albums } from 'ionicons/icons'
+<script setup>
+import { defineProps } from 'vue'
+import { IonItem, IonLabel, IonImg, IonIcon, IonPopover, IonList } from '@ionic/vue'
+import * as icons from '@/icons'
 
-export default {
-  components: { IonItem, IonLabel, IonImg, IonIcon },
-
-  props: {
-    album: {
-      type: Object,
-      required: true
-    }
+defineProps({
+  album: {
+    type: Object,
+    required: true
   },
-
-  data () {
-    return { albums }
+  showArtist: {
+    type: Boolean,
+    default: true
   }
-}
+})
 </script>

--- a/app/frontend/components/SongsheetItem.vue
+++ b/app/frontend/components/SongsheetItem.vue
@@ -2,6 +2,7 @@
   <ion-item
     button
     :router-link="{ name: 'songsheet', params: { id: songsheet.id } }"
+    detail="false"
   >
     <ion-avatar
       slot="start"
@@ -14,7 +15,7 @@
       />
       <ion-icon
         v-else
-        :icon="musicalNote"
+        :icon="icons.song"
         class="text-slate-300"
       />
     </ion-avatar>
@@ -24,15 +25,53 @@
         {{ artist }}
       </p>
     </ion-label>
+    <ion-button
+      :id="`songsheet-${songsheet.id}`"
+      slot="end"
+      fill="clear"
+      color="dark"
+      @click.prevent=""
+    >
+      <ion-icon
+        slot="icon-only"
+        size="small"
+        :ios="icons.iosEllipsis"
+        :md="icons.mdEllipsis"
+      />
+    </ion-button>
+    <ion-popover
+      :trigger="`songsheet-${songsheet.id}`"
+      translucent
+      dismiss-on-select
+    >
+      <ion-list lines="full">
+        <ion-item
+          v-if="songsheet.track"
+          button
+          :detail-icon="icons.artist"
+          :router-link="{ name: 'artist', params: { id: songsheet.track?.artist?.id } }"
+        >
+          View Artist
+        </ion-item>
+        <ion-item
+          v-if="songsheet.track"
+          button
+          :detail-icon="icons.album"
+          :router-link="{ name: 'album', params: { id: songsheet.track?.album?.id } }"
+        >
+          View Album
+        </ion-item>
+      </ion-list>
+    </ion-popover>
   </ion-item>
 </template>
 
 <script>
-import { IonItem, IonAvatar, IonLabel, IonImg, IonIcon } from '@ionic/vue'
-import { musicalNote } from 'ionicons/icons'
+import { IonItem, IonAvatar, IonLabel, IonImg, IonIcon, IonButton, IonPopover, IonList } from '@ionic/vue'
+import * as icons from '@/icons'
 
 export default {
-  components: { IonItem, IonAvatar, IonLabel, IonImg, IonIcon },
+  components: { IonItem, IonAvatar, IonLabel, IonImg, IonIcon, IonButton, IonPopover, IonList },
 
   props: {
     songsheet: {
@@ -42,7 +81,9 @@ export default {
   },
 
   data () {
-    return { musicalNote }
+    return {
+      icons
+    }
   },
 
   computed: {

--- a/app/frontend/components/TrackItem.vue
+++ b/app/frontend/components/TrackItem.vue
@@ -2,6 +2,8 @@
   <ion-item
     button
     :router-link="{ name: 'track', params: { id: track.id } }"
+    detail="false"
+    :class="{ 'opacity-40 hover:opacity-100 transition-opacity': !track.has_songsheet }"
   >
     <ion-avatar slot="start">
       <ion-img
@@ -13,20 +15,66 @@
       <h2>{{ track.title }}</h2>
       <p>{{ track.artist.name }}</p>
     </ion-label>
+
+    <ion-button
+      :id="`track-${track.id}`"
+      slot="end"
+      fill="clear"
+      color="medium"
+      @click.prevent=""
+    >
+      <ion-icon
+        slot="icon-only"
+        size="small"
+        :ios="icons.iosEllipsis"
+        :md="icons.mdEllipsis"
+      />
+    </ion-button>
+    <ion-popover
+      :trigger="`track-${track.id}`"
+      side="bottom"
+      alignment="end"
+      translucent
+      dismiss-on-select
+      animated
+    >
+      <ion-list lines="full">
+        <ion-item
+          v-if="!track.has_songsheet"
+          button
+          :router-link="{ name: 'songsheet.new', query: { track: track.id }}"
+        >
+          Create Songsheet
+        </ion-item>
+        <ion-item
+          button
+          :detail-icon="icons.artist"
+          :router-link="{ name: 'artist', params: { id: track.artist?.id } }"
+        >
+          View Artist
+        </ion-item>
+        <ion-item
+          v-if="track.album"
+          button
+          :detail-icon="icons.album"
+          :router-link="{ name: 'album', params: { id: track.album.id } }"
+        >
+          View Album
+        </ion-item>
+      </ion-list>
+    </ion-popover>
   </ion-item>
 </template>
 
-<script>
-import { IonItem, IonAvatar, IonLabel, IonImg } from '@ionic/vue'
+<script setup>
+import { defineProps } from 'vue'
+import { IonItem, IonAvatar, IonLabel, IonImg, IonIcon, IonButton, IonPopover, IonList } from '@ionic/vue'
+import * as icons from '@/icons'
 
-export default {
-  components: { IonItem, IonAvatar, IonLabel, IonImg },
-
-  props: {
-    track: {
-      type: Object,
-      required: true
-    }
+defineProps({
+  track: {
+    type: Object,
+    required: true
   }
-}
+})
 </script>

--- a/app/frontend/components/menu.vue
+++ b/app/frontend/components/menu.vue
@@ -60,7 +60,7 @@
             <ion-icon
               slot="start"
               size="small"
-              :icon="icons.musicalNote"
+              :icon="icons.song"
             />
             Songs
           </ion-item>
@@ -77,7 +77,7 @@
             <ion-icon
               slot="start"
               size="small"
-              :icon="icons.peopleCircle"
+              :icon="icons.artist"
             />
             Artists
           </ion-item>
@@ -102,7 +102,7 @@ import {
   IonMenuToggle
 } from '@ionic/vue'
 
-import { search, musicalNote, peopleCircle } from 'ionicons/icons'
+import * as icons from '@/icons'
 
 export default {
   components: {
@@ -121,7 +121,7 @@ export default {
 
   data () {
     return {
-      icons: { search, musicalNote, peopleCircle },
+      icons,
       selected: this.$route.meta?.selected || 'discover'
     }
   },

--- a/app/frontend/icons.js
+++ b/app/frontend/icons.js
@@ -1,0 +1,8 @@
+export {
+  search,
+  musicalNote as song,
+  peopleCircleOutline as artist,
+  ellipsisHorizontal as iosEllipsis,
+  ellipsisVertical as mdEllipsis,
+  albumsOutline as album
+} from 'ionicons/icons'

--- a/app/frontend/views/AlbumView.vue
+++ b/app/frontend/views/AlbumView.vue
@@ -83,11 +83,11 @@
 
 <script>
 import client from '@/client'
-import { IonPage, IonHeader, IonToolbar, IonTitle, IonContent, IonButtons, IonBackButton, IonList, IonLabel, IonItem, IonText, IonNote } from '@ionic/vue'
+import { IonPage, IonHeader, IonToolbar, IonTitle, IonContent, IonButtons, IonBackButton, IonList, IonLabel, IonItem, IonText, IonNote, IonIcon } from '@ionic/vue'
 import { albums } from 'ionicons/icons'
 
 export default {
-  components: { IonPage, IonHeader, IonToolbar, IonTitle, IonContent, IonButtons, IonBackButton, IonList, IonLabel, IonItem, IonText, IonNote },
+  components: { IonPage, IonHeader, IonToolbar, IonTitle, IonContent, IonButtons, IonBackButton, IonList, IonLabel, IonItem, IonText, IonNote, IonIcon },
 
   props: {
     id: {

--- a/app/frontend/views/ArtistView.vue
+++ b/app/frontend/views/ArtistView.vue
@@ -37,18 +37,13 @@
         </div>
       </ion-header>
 
-      <ion-list v-if="tracks.length > 0 || songsheets.length > 0">
+      <ion-list v-if="tracks.length > 0">
         <ion-list-header>
           <ion-label>Top Songs</ion-label>
           <ion-button>See All</ion-button>
         </ion-list-header>
 
         <div class="grid-scroll-x grid-rows-3 auto-cols-1/1 sm:auto-cols-1/2 lg:auto-cols-1/3 xl:auto-cols-1/4">
-          <songsheet-item
-            v-for="songsheet in songsheets"
-            :key="songsheet.id"
-            :songsheet="songsheet"
-          />
           <track-item
             v-for="track in tracks"
             :key="track.id"
@@ -71,6 +66,7 @@
             v-for="album in albums"
             :key="album.id"
             :album="album"
+            :show-artist="false"
           />
         </div>
       </ion-list>
@@ -97,10 +93,9 @@ import client from '@/client'
 import { IonPage, IonHeader, IonToolbar, IonTitle, IonContent, IonButtons, IonBackButton, IonList, IonListHeader, IonLabel, IonButton, IonNote } from '@ionic/vue'
 import TrackItem from '@/components/TrackItem.vue'
 import AlbumItem from '@/components/AlbumItem.vue'
-import SongsheetItem from '@/components/SongsheetItem.vue'
 
 export default {
-  components: { SongsheetItem, TrackItem, AlbumItem, IonPage, IonHeader, IonToolbar, IonTitle, IonContent, IonButtons, IonBackButton, IonList, IonListHeader, IonLabel, IonButton, IonNote },
+  components: { TrackItem, AlbumItem, IonPage, IonHeader, IonToolbar, IonTitle, IonContent, IonButtons, IonBackButton, IonList, IonListHeader, IonLabel, IonButton, IonNote },
 
   props: {
     id: {
@@ -113,8 +108,7 @@ export default {
     return {
       artist: {},
       tracks: [],
-      albums: [],
-      songsheets: []
+      albums: []
     }
   },
 
@@ -133,9 +127,6 @@ export default {
         }),
         client.get(`/api/artists/${this.id}/tracks.json`).then(response => {
           this.tracks = response.data
-        }),
-        client.get(`/api/artists/${this.id}/songsheets.json`).then(response => {
-          this.songsheets = response.data
         })
       ])
     }


### PR DESCRIPTION
Adds a  … menu on tracks and albums to easily jump around. Later these menus will have actions like "Save to library…" and "Add to setlist…"

<img width="414" alt="image" src="https://user-images.githubusercontent.com/173/153033877-912e205a-c035-4694-a1ac-fa1ae1a9ac38.png">
