### PR TITLE
Add rank based on number of players

### DIFF
--- a/app/jobs/update_rank.rb
+++ b/app/jobs/update_rank.rb
@@ -1,0 +1,170 @@
+# Updates `rank` column on all models
+class UpdateRank < ApplicationJob
+  queue_as :low
+
+  WINDOW = 1.month
+
+  def perform
+    rank_songsheets
+    rank_tracks
+    rank_albums
+    rank_artists
+    rank_genres
+  end
+
+  # Rank songsheets by:
+  # 1. Number of distinct recent players (all anonymous users count as 1)
+  # 2. Number of track listeners
+  # 3. Newest to oldest
+  def rank_songsheets
+    exec <<-EOQ, since: WINDOW.ago
+      WITH
+        players AS (
+          SELECT (properties->>'songsheet_id')::bigint AS id, COUNT(DISTINCT user_id) AS count
+          FROM ahoy_events
+          WHERE name = 'play' AND time > :since
+          GROUP BY properties->>'songsheet_id'
+        ),
+        ranked as (
+          SELECT
+            songsheets.id,
+            ROW_NUMBER() OVER (
+              ORDER BY
+                players.count DESC NULLS LAST,
+                tracks.listeners DESC NULLS LAST,
+                songsheets.created_at DESC
+            ) AS row
+          FROM songsheets
+          LEFT OUTER JOIN players ON songsheets.id = players.id
+          LEFT OUTER JOIN tracks ON songsheets.track_id = tracks.id
+        )
+      UPDATE songsheets
+      SET rank = ranked.row
+      FROM ranked
+      WHERE ranked.id = songsheets.id
+    EOQ
+  end
+
+  # Rank tracks by:
+  # 1. Number of distinct recent players
+  # 2. Having at least 1 songsheet
+  # 3. Number of listeners
+  def rank_tracks
+    exec <<-EOQ, since: WINDOW.ago
+      WITH
+        players AS (
+          SELECT songsheets.track_id, COUNT(DISTINCT ahoy_events.user_id) AS count
+          FROM ahoy_events
+          JOIN songsheets ON songsheets.id = (properties->>'songsheet_id')::bigint
+          WHERE name = 'play' AND time > :since
+          GROUP BY 1
+        ),
+        ranked AS (
+          SELECT
+            tracks.id,
+            ROW_NUMBER() over (ORDER BY
+              players.count DESC NULLS LAST,
+              CASE WHEN songsheets_count > 0 THEN 1 ELSE 2 END,
+              tracks.listeners DESC NULLS LAST
+            ) AS row
+          FROM tracks
+          LEFT OUTER JOIN players ON tracks.id = players.track_id
+        )
+      UPDATE tracks
+      SET rank = ranked.row
+      FROM ranked
+      WHERE ranked.id = tracks.id
+    EOQ
+  end
+
+  # Rank albums by average track rank
+  def rank_albums
+    exec <<-EOQ
+      WITH
+        avg_track_rank AS (
+          SELECT album_id AS id, AVG(rank) AS rank
+          FROM tracks
+          GROUP BY album_id
+        ),
+        ranked AS (
+          SELECT albums.id, ROW_NUMBER() over (ORDER BY avg_track_rank.rank) AS row
+          FROM albums
+          LEFT OUTER JOIN avg_track_rank ON avg_track_rank.id = albums.id
+        )
+      UPDATE albums
+      SET rank = ranked.row
+      FROM ranked
+      WHERE ranked.id = albums.id
+    EOQ
+  end
+
+  # Rank artists by:
+  # 1. Number of distinct recent players
+  # 2. Number of listeners
+  def rank_artists
+    exec <<-EOQ, since: WINDOW.ago
+      WITH
+        players AS (
+          SELECT artist_works.artist_id, COUNT(DISTINCT ahoy_events.user_id) AS count
+          FROM ahoy_events
+          JOIN artist_works ON artist_works.work_id = (properties->>'songsheet_id')::bigint
+            AND artist_works.work_type = 'Songsheet'
+          WHERE name = 'play' AND time > :since
+          GROUP BY 1
+        ),
+        ranked AS (
+          SELECT
+            artists.id,
+            ROW_NUMBER() over (ORDER BY
+              players.count DESC NULLS LAST,
+              artists.listeners DESC NULLS LAST
+            ) AS row
+          FROM artists
+          LEFT OUTER JOIN players ON artists.id = players.artist_id
+        )
+      UPDATE artists
+      SET rank = ranked.row
+      FROM ranked
+      WHERE ranked.id = artists.id
+    EOQ
+  end
+
+  # Rank artists by:
+  # 1. Number of distinct recent players
+  # 2. Number of listeners
+  def rank_genres
+    exec <<-EOQ, since: WINDOW.ago
+      WITH
+        players AS (
+          SELECT tracks.genre_id, COUNT(DISTINCT user_id) AS count
+          FROM ahoy_events
+          JOIN songsheets ON songsheets.id = (properties->>'songsheet_id')::bigint
+          JOIN tracks ON tracks.id = songsheets.track_id
+          WHERE name = 'play' AND time > :since
+          GROUP BY 1
+        ),
+        ranked AS (
+          SELECT
+            genres.id,
+            ROW_NUMBER() over (ORDER BY
+              players.count DESC NULLS LAST,
+              genres.listeners DESC NULLS LAST
+            ) AS row
+          FROM genres
+          LEFT OUTER JOIN players ON players.genre_id = genres.id
+        )
+      UPDATE genres
+      SET rank = ranked.row
+      FROM ranked
+      WHERE ranked.id = genres.id
+    EOQ
+  end
+
+  def exec(query, params = {})
+    ApplicationRecord.connection.execute sanitize_sql(query, params)
+  end
+
+  def sanitize_sql(sql, params = {})
+    ApplicationRecord.sanitize_sql([sql, params])
+  end
+end

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -8,7 +8,7 @@ class Album < ApplicationRecord
 
   before_validation :associate_genre
 
-  scope :order_by_popular, -> { order("albums.listeners DESC NULLS LAST") }
+  scope :order_by_popular, -> { order("albums.rank") }
   scope :order_by_released, ->(dir = :desc) { order(released: "#{dir} NULLS LAST") }
 
   searchkick word_start: [:title, :everything], stem: false, callbacks: :async

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -17,7 +17,7 @@ class Artist < ApplicationRecord
   searchkick word_start: [:title], stem: false, callbacks: :async
   scope :verified, -> { where(verified: true) }
   scope :order_by_alphabetical, -> { order("UPPER(name)") }
-  scope :order_by_popular, -> { order("listeners DESC NULLS LAST") }
+  scope :order_by_popular, -> { order("artists.rank") }
 
   def self.lookup(name)
     search(name, boost_by: [:boost], fields: ["everything"]).first

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -8,5 +8,5 @@ class Genre < ApplicationRecord
   has_one :example_track, -> { Track.order_by_popular }, class_name: "Track"
   has_one :example_artist, through: :example_track, class_name: "Artist", source: :artist
 
-  scope :order_by_popular, -> { order("listeners DESC NULLS LAST") }
+  scope :order_by_popular, -> { order("genres.rank") }
 end

--- a/app/models/songsheet.rb
+++ b/app/models/songsheet.rb
@@ -10,9 +10,7 @@ class Songsheet < ApplicationRecord
   has_many :artists, through: :artist_works
   has_many :media, as: :record
 
-  scope :order_by_popular, -> {
-    includes(:track).order("tracks.listeners DESC NULLS LAST").order_by_recent
-  }
+  scope :order_by_popular, -> { order("songsheets.rank") }
   scope :order_by_recent, -> { order(created_at: :desc) }
   scope :order_by_todo, -> { order(Arel.sql("track_id NULLS FIRST, updated_at ASC")) }
 

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -15,9 +15,7 @@ class Track < ApplicationRecord
   scope :order_by_has_songsheet, -> {
     order(Arel.sql("CASE WHEN songsheets_count > 0 THEN 1 ELSE 2 END"))
   }
-  scope :order_by_popular, -> {
-    order_by_has_songsheet.order("tracks.listeners DESC NULLS LAST")
-  }
+  scope :order_by_popular, -> { order("tracks.rank") }
   scope :order_by_number, -> { order(:number) }
   scope :with_songsheet, -> { where(songsheets_count: 1..) }
 

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -10,6 +10,7 @@ Rails.application.configure do
   config.good_job.enable_cron = true
   config.good_job.cron = {
     popular: {cron: "every day", class: "UpdatePopularCounts"},
+    rank: {cron: "every day", class: "UpdateRank"},
     tokens: {cron: "every day", class: "CleanupTokens"},
     opt_outs: {cron: "every day", class: "PerformableMethod", args: [Mailkick, :fetch_opt_outs]}
   }

--- a/db/migrate/20220618132541_add_rank.rb
+++ b/db/migrate/20220618132541_add_rank.rb
@@ -1,0 +1,10 @@
+class AddRank < ActiveRecord::Migration[7.0]
+  def change
+    add_column :songsheets, :rank, :bigint
+    add_column :tracks, :rank, :bigint
+    add_column :albums, :rank, :bigint
+    add_column :artists, :rank, :bigint
+    add_column :setlists, :rank, :bigint
+    add_column :genres, :rank, :bigint
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -206,7 +206,8 @@ CREATE TABLE public.albums (
     released integer,
     score numeric(3,1),
     genre_id bigint,
-    listeners bigint
+    listeners bigint,
+    rank bigint
 );
 
 
@@ -286,7 +287,8 @@ CREATE TABLE public.artists (
     style character varying,
     genre_id bigint,
     verified boolean DEFAULT false,
-    listeners bigint
+    listeners bigint,
+    rank bigint
 );
 
 
@@ -319,7 +321,8 @@ CREATE TABLE public.genres (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     thumbnail character varying,
-    listeners bigint
+    listeners bigint,
+    rank bigint
 );
 
 
@@ -528,7 +531,8 @@ CREATE TABLE public.setlists (
     description text,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    user_id bigint
+    user_id bigint,
+    rank bigint
 );
 
 
@@ -563,7 +567,8 @@ CREATE TABLE public.songsheets (
     metadata json,
     track_id bigint,
     title character varying,
-    imported_from character varying
+    imported_from character varying,
+    rank bigint
 );
 
 
@@ -602,7 +607,8 @@ CREATE TABLE public.tracks (
     duration integer,
     listeners bigint,
     genre_id bigint,
-    songsheets_count integer DEFAULT 0
+    songsheets_count integer DEFAULT 0,
+    rank bigint
 );
 
 
@@ -1346,6 +1352,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220524012457'),
 ('20220527124410'),
 ('20220614211748'),
-('20220618131530');
+('20220618131530'),
+('20220618132541');
 
 

--- a/test/jobs/update_rank_test.rb
+++ b/test/jobs/update_rank_test.rb
@@ -1,0 +1,115 @@
+require "test_helper"
+
+class UpdateRankTest < ActiveJob::TestCase
+  test "ranks songsheets by plays" do
+    played_many = create :songsheet
+    unplayed = create :songsheet
+    played_once = create :songsheet
+
+    play played_many, times: 2
+    play played_once
+
+    UpdateRank.new.perform
+
+    assert_equal 1, played_many.reload.rank
+    assert_equal 2, played_once.reload.rank
+    assert_equal 3, unplayed.reload.rank
+  end
+
+  test "ranks tracks by songsheet plays, listeners" do
+    listeners = create :track, listeners: 1_000_000
+    no_listeners = create :track, listeners: nil
+    played_many = create :songsheet, track: create(:track)
+    played_once = create :songsheet, track: create(:track)
+    played_never = create :songsheet, track: create(:track)
+
+    play played_many, times: 2
+    play played_once
+
+    UpdateRank.new.perform
+
+    assert_equal 1, played_many.track.reload.rank
+    assert_equal 2, played_once.track.reload.rank
+    assert_equal 3, played_never.track.reload.rank
+    assert_equal 4, listeners.reload.rank
+    assert_equal 5, no_listeners.reload.rank
+  end
+
+  test "ranks albums by avg track rank" do
+    high_avg = create :album, tracks: [
+      create(:track, rank: 1),
+      create(:track, rank: 5),
+      create(:track, rank: 10),
+      create(:track, rank: 31)
+    ]
+
+    low_avg = create :album, tracks: [
+      create(:track, rank: 20),
+      create(:track, rank: 30),
+      create(:track, rank: 40),
+      create(:track, rank: 50)
+    ]
+
+    UpdateRank.new.rank_albums
+
+    assert_equal 1, high_avg.reload.rank
+    assert_equal 2, low_avg.reload.rank
+  end
+
+  test "ranks artists by songsheet players" do
+    popular = create :artist
+    less_popular = create :artist
+    listeners = create :artist, listeners: 1000
+    no_listeners = create :artist, listeners: nil
+
+    # 3 songsheets with the same 2 players each
+    create(:songsheet, artists: [less_popular]).tap { |s| play s, times: 2 }
+    create(:songsheet, artists: [less_popular]).tap { |s| play s, times: 2 }
+    create(:songsheet, artists: [less_popular]).tap { |s| play s, times: 2 }
+
+    # One songsheet with 5 players
+    create(:songsheet, artists: [popular]).tap { |s| play s, times: 5 }
+
+    UpdateRank.new.rank_artists
+
+    assert_equal 1, popular.reload.rank
+    assert_equal 2, less_popular.reload.rank
+    assert_equal 3, listeners.reload.rank
+    assert_equal 4, no_listeners.reload.rank
+  end
+
+  test "ranks generes by songsheet players" do
+    popular = create :genre
+    less_popular = create :genre
+    listeners = create :genre, listeners: 1000
+    no_listeners = create :genre, listeners: nil
+
+    # 3 songsheets with the same 2 players each
+    create(:songsheet, track: create(:track, genre: less_popular)).tap { |s| play s, times: 2 }
+    create(:songsheet, track: create(:track, genre: less_popular)).tap { |s| play s, times: 2 }
+    create(:songsheet, track: create(:track, genre: less_popular)).tap { |s| play s, times: 2 }
+
+    # One songsheet with 5 players
+    create(:songsheet, track: create(:track, genre: popular)).tap { |s| play s, times: 5 }
+
+    UpdateRank.new.rank_genres
+
+    assert_equal 1, popular.reload.rank
+    assert_equal 2, less_popular.reload.rank
+    assert_equal 3, listeners.reload.rank
+    assert_equal 4, no_listeners.reload.rank
+  end
+
+  def play(songsheet, at: Time.now, times: 1)
+    times.times do |i|
+      visit = Ahoy::Visit.create! user_id: i
+      Ahoy::Event.create!(
+        visit: visit,
+        user_id: i,
+        name: "play",
+        properties: {songsheet_id: songsheet.id},
+        time: at
+      )
+    end
+  end
+end


### PR DESCRIPTION
This adds a `rank` field to songsheets, tracks, albums, artists, and genres. A job will run daily to update the rank, mostly based on the number of distinct players (where a "play" event is currently just viewing a songsheet, and all unauthenticated players count as 1 player) in the last month.