### PR TITLE
Allow unauthorized access for reading setlist

### DIFF
--- a/app/controllers/api/setlist_items_controller.rb
+++ b/app/controllers/api/setlist_items_controller.rb
@@ -1,6 +1,7 @@
 class Api::SetlistItemsController < ApiController
   before_action :find_setlist, except: :index
   before_action :find_item, only: [:update, :destroy]
+  skip_before_action :authenticate!, only: %i[index]
 
   def index
     @items = Setlist.find_by_uid(params[:setlist_id]).items.includes(:songsheet).page(params[:page])

--- a/app/controllers/api/setlists_controller.rb
+++ b/app/controllers/api/setlists_controller.rb
@@ -1,5 +1,5 @@
 class Api::SetlistsController < ApiController
-  before_action :authenticate!, except: %i[show]
+  skip_before_action :authenticate!, only: %i[show]
 
   def index
     @setlists = current_user.setlists.order_by_recent.page(params[:page])

--- a/test/controllers/api/setlist_controller_test.rb
+++ b/test/controllers/api/setlist_controller_test.rb
@@ -5,6 +5,11 @@ class Api::SetlistsControllerTest < ActionDispatch::IntegrationTest
     @user = create :user
   end
 
+  test "show unauthenticated" do
+    get api_setlist_url(create(:setlist), format: :json)
+    assert_response :success
+  end
+
   test "index requires authentication" do
     get api_setlists_url(format: :json)
     assert_response :unauthorized

--- a/test/controllers/api/setlist_items_controller_test.rb
+++ b/test/controllers/api/setlist_items_controller_test.rb
@@ -6,6 +6,11 @@ class Api::SetlistItemsControllerTest < ActionDispatch::IntegrationTest
     @setlist = create :setlist, user: @user
   end
 
+  test "index unauthenticated" do
+    get api_setlist_items_url(@setlist, format: :json)
+    assert_response :success
+  end
+
   test "create unauthenticated" do
     post api_setlist_items_url(@setlist)
     assert_response :unauthorized


### PR DESCRIPTION
Currently returning 401 for all anonymous users, but they should should always be able to view setlists.